### PR TITLE
Tamanio de paginas

### DIFF
--- a/proceso_cpu.md
+++ b/proceso_cpu.md
@@ -4,9 +4,9 @@ Este proceso es uno de los más importantes del trabajo ya que es el encargado d
 
 Estará en permanente contacto con el Proceso UMC, tanto para obtener información del Programa en ejecución, como para actualizar las estructuras requeridas luego de ejecutar una operación.
 
-Al iniciar, se conectará al proceso Núcleo y quedará a la espera de que este le envíe el PCB de un Programa AnSISOP para ejecutarlo.
+Al iniciar, se conectará a la UMC y obtendrá el tamaño de página a utilizar. Además se conectará al proceso Núcleo y quedará a la espera de que este le envíe el PCB de un Programa AnSISOP para ejecutarlo.
 
-Incrementará el valor del registro Program Counter del PCB y utilizará el índice de código para solicitar a la UMC la próxima sentencia a ejecutar. Al recibirla, la parseará, ejecutará las operaciones requeridas, actualizará los valores del Programa en la UMC, actualizará el Program Counter en el PCB y notificará al Núcleo que concluyó un **quantum**[^14].
+Incrementará el valor del registro Program Counter del PCB y utilizará el índice de código para solicitar a la UMC la(s) página(s) donde se encuentre la próxima sentencia a ejecutar. Al recibirla(s), extraerá la instrucción, la parseará, ejecutará las operaciones requeridas, actualizará los valores del Programa en la UMC, actualizará el Program Counter en el PCB y notificará al Núcleo que concluyó un **quantum**[^14].
 
 ### Ejemplo
 

--- a/proceso_nucleo.md
+++ b/proceso_nucleo.md
@@ -4,7 +4,7 @@ El proceso Núcleo es el proceso principal del sistema. Recibirá los Programa
 
 ## Arquitectura del Proceso Núcleo
 
-El proceso Núcleo al ser iniciado se conectará con el Proceso Unidad de Memoria Central (UMC) y quedará a la espera de conexiones por parte de Procesos CPU o Procesos Consola.
+El proceso Núcleo al ser iniciado se conectará con el Proceso Unidad de Memoria Central (UMC), obtendrá el tamaño de página, y quedará a la espera de conexiones por parte de Procesos CPU o Procesos Consola.
 
 Al contar con al menos un Proceso CPU comenzará a planificar los diversos Programas AnSISOP en función del algoritmo de planificación.
 
@@ -86,6 +86,7 @@ Al iniciar, el Proceso Núcleo deberá leer los siguientes parámetros de un arc
 | `IO_IDS` | [array: alfanumérico] | Identificador de cada dispositivo de entrada/salida |
 | `IO_SLEEP` | [array: numérico] | Retardo en milisegundos de cada unidad de operación de entrada/salida de cada dispositivo definido en IO_IDS, según su posición |
 | `SHARED_VARS` | [array: alfanumérico] | Identificador de cada variable compartida |
+| `STACK_SIZE` | [numérico] | Tamaño en páginas del Stack |
 
 ### Ejemplo de Archivo de Configuración
 
@@ -99,6 +100,7 @@ IO_SLEEP=[1000, 2000, 1000]
 SEM_ID=[SEM1, SEM2, SEM3]
 SEM_INIT=[0, 0, 5]
 SHARED_VARS=[!Global, !UnaVar, !tiempo3]
+STACK_SIZE=2
 ```
 
 Como se observa en el ejemplo el `SEM3` es inicializado con valor 5 y la `Impresora` tiene un retardo de 2000ms. Las variables compartidas `!Global`, `!Unavar`, y `!tiempo3` se inicializan en cero.

--- a/proceso_nucleo.md
+++ b/proceso_nucleo.md
@@ -4,7 +4,7 @@ El proceso Núcleo es el proceso principal del sistema. Recibirá los Programa
 
 ## Arquitectura del Proceso Núcleo
 
-El proceso Núcleo al ser iniciado se conectará con el Proceso Unidad de Memoria Central (UMC) y quedará a la espera de conexiones por parte de Procesos CPU o Procesos Consola.
+El proceso Núcleo al ser iniciado se conectará con el Proceso Unidad de Memoria Central (UMC), obtendrá el tamaño de pagina, y quedará a la espera de conexiones por parte de Procesos CPU o Procesos Consola.
 
 Al contar con al menos un Proceso CPU comenzará a planificar los diversos Programas AnSISOP en función del algoritmo de planificación.
 
@@ -86,6 +86,7 @@ Al iniciar, el Proceso Núcleo deberá leer los siguientes parámetros de un arc
 | `IO_IDS` | [array: alfanumérico] | Identificador de cada dispositivo de entrada/salida |
 | `IO_SLEEP` | [array: numérico] | Retardo en milisegundos de cada unidad de operación de entrada/salida de cada dispositivo definido en IO_IDS, según su posición |
 | `SHARED_VARS` | [array: alfanumérico] | Identificador de cada variable compartida |
+| `STACK_SIZE` | [array: alfanumérico] | Tamaño en páginas del Stack |
 
 ### Ejemplo de Archivo de Configuración
 
@@ -99,6 +100,7 @@ IO_SLEEP=[1000, 2000, 1000]
 SEM_ID=[SEM1, SEM2, SEM3]
 SEM_INIT=[0, 0, 5]
 SHARED_VARS=[!Global, !UnaVar, !tiempo3]
+STACK_SIZE=2
 ```
 
 Como se observa en el ejemplo el `SEM3` es inicializado con valor 5 y la `Impresora` tiene un retardo de 2000ms. Las variables compartidas `!Global`, `!Unavar`, y `!tiempo3` se inicializan en cero.


### PR DESCRIPTION
- Al iniciar, el proceso CPU debe obtener el tamaño de pagina que utiliza la UMC. Con este valor luego podrá calcular cual/cuales pagina/s solicitar cada vez que requiera ejecutar una instruccion.
- El archivo de configuración del config debe contener un parametro STACK_SIZE que representa el tamaño en paginas del Stack.
