### PR TITLE
Las operaciones de `wait` y `signal` no deberían retornar

### DIFF
--- a/anexo_iii_-_primitivas_de_ansisop.md
+++ b/anexo_iii_-_primitivas_de_ansisop.md
@@ -129,7 +129,7 @@ int entradaSalida(t_nombre_dispositivo dispositivo, int tiempo)
 Informa al Núcleo que ejecute la función wait para el semáforo con el nombre `identificador_semaforo`. El Núcleo deberá decidir si bloquearlo o no.
 
 ```
-int wait(t_nombre_semaforo identificador_semaforo)
+void wait(t_nombre_semaforo identificador_semaforo)
 ```
 
 ### 14. `signal`
@@ -137,5 +137,5 @@ int wait(t_nombre_semaforo identificador_semaforo)
 Comunica al Núcleo que ejecute la función signal para el semáforo con el nombre `identificador_semaforo`. El Núcleo decidirá si esto conlleva desbloquear a otros procesos.
 
 ```
-int signal(t_nombre_semaforo identificador_semaforo)
+void signal(t_nombre_semaforo identificador_semaforo)
 ```


### PR DESCRIPTION
https://github.com/sisoputnfrba/foro/issues/320

https://github.com/sisoputnfrba/ansisop-parser/blob/055312c3a2ba986d8283dd9e845d188f0d486cb9/parser/parser/parser.h#L230-L252
